### PR TITLE
Fix plain/text header for script

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
     </footer>
   </div>
 
-  <script type="text/javascript" src="https://raw.githubusercontent.com/distroid/share-it/master/lib/share-it.min.js" charset="utf-8"></script>
+  <script type="text/javascript" src="https://rawgit.com/distroid/share-it/master/lib/share-it.min.js" charset="utf-8"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Fix error when In chromium based browsers (and latest firefox) demo didn't display.
